### PR TITLE
Add option to hide accordion by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ https://user-images.githubusercontent.com/22506439/227396634-7a63671a-fd38-419a-
 
 ## Settings
 
-- Expand by default (`False`)
+- Hide accordion by default (`False`)
+- Expand accordion by default (`False`)
   - Determines whether the 'Aspect Ratio Helper' accordion expands by default
 - UI Component order (`MaxDimensionScaler, PredefinedAspectRatioButtons, PredefinedPercentageButtons`)
   - Determines the order in which the UI components will render
@@ -60,6 +61,9 @@ https://user-images.githubusercontent.com/22506439/227396634-7a63671a-fd38-419a-
   - `Multiplication (x0.5, x1.5)`
 
 ![settings.png](docs%2Fopts.png)
+
+
+JavaScript & accordion aspect ratios _might_ not play well together - I don't think many users will use both simultaneously, but we'll see.
 
 ## Contributing
 

--- a/aspect_ratio_helper/_constants.py
+++ b/aspect_ratio_helper/_constants.py
@@ -4,6 +4,7 @@ MAX_DIMENSION = 2048
 MIN_DIMENSION = 64
 
 ARH_EXPAND_BY_DEFAULT_KEY = 'arh_expand_by_default'
+ARH_HIDE_ACCORDION_BY_DEFAULT_KEY = 'arh_hide_accordion_by_default'
 ARH_UI_COMPONENT_ORDER_KEY = 'arh_ui_component_order_key'
 ARH_JAVASCRIPT_ASPECT_RATIO_SHOW_KEY = 'arh_javascript_aspect_ratio_show'
 ARH_JAVASCRIPT_ASPECT_RATIOS_KEY = 'arh_javascript_aspect_ratio'

--- a/aspect_ratio_helper/_settings.py
+++ b/aspect_ratio_helper/_settings.py
@@ -25,6 +25,7 @@ DEFAULT_UI_COMPONENT_ORDER_KEY = ', '.join(
 )
 OPT_KEY_TO_DEFAULT_MAP = {
     _constants.ARH_EXPAND_BY_DEFAULT_KEY: False,
+    _constants.ARH_HIDE_ACCORDION_BY_DEFAULT_KEY: False,
     _constants.ARH_UI_COMPONENT_ORDER_KEY:
         DEFAULT_UI_COMPONENT_ORDER_KEY,
     _constants.ARH_JAVASCRIPT_ASPECT_RATIO_SHOW_KEY: False,
@@ -87,35 +88,7 @@ def sort_components_by_keys(
 
 
 def on_ui_settings():
-    # default ui options
-    shared.opts.add_option(
-        key=_constants.ARH_EXPAND_BY_DEFAULT_KEY,
-        info=shared.OptionInfo(
-            default=OPT_KEY_TO_DEFAULT_MAP.get(
-                _constants.ARH_EXPAND_BY_DEFAULT_KEY,
-            ),
-            label='Expand by default',
-            section=_constants.SECTION,
-        ),
-    )
-    shared.opts.add_option(
-        key=_constants.ARH_UI_COMPONENT_ORDER_KEY,
-        info=shared.OptionInfo(
-            default=OPT_KEY_TO_DEFAULT_MAP.get(
-                _constants.ARH_UI_COMPONENT_ORDER_KEY,
-            ),
-            label='UI Component order',
-            component=gr.Dropdown,
-            component_args=lambda: {
-                'choices': [
-                    ', '.join(p) for p in itertools.permutations(
-                        DEFAULT_UI_COMPONENT_ORDER_KEY_LIST,
-                    )
-                ],
-            },
-            section=_constants.SECTION,
-        ),
-    )
+    # javascript ui options
     shared.opts.add_option(
         key=_constants.ARH_JAVASCRIPT_ASPECT_RATIO_SHOW_KEY,
         info=shared.OptionInfo(
@@ -134,6 +107,46 @@ def on_ui_settings():
             ),
             label='JavaScript aspect ratio buttons'
                   ' (1:1, 4:3, 16:9, 9:16, 21:9)',
+            section=_constants.SECTION,
+        ),
+    )
+
+    # accordion options
+    shared.opts.add_option(
+        key=_constants.ARH_HIDE_ACCORDION_BY_DEFAULT_KEY,
+        info=shared.OptionInfo(
+            default=OPT_KEY_TO_DEFAULT_MAP.get(
+                _constants.ARH_HIDE_ACCORDION_BY_DEFAULT_KEY,
+            ),
+            label='Hide accordion by default',
+            section=_constants.SECTION,
+        ),
+    )
+    shared.opts.add_option(
+        key=_constants.ARH_EXPAND_BY_DEFAULT_KEY,
+        info=shared.OptionInfo(
+            default=OPT_KEY_TO_DEFAULT_MAP.get(
+                _constants.ARH_EXPAND_BY_DEFAULT_KEY,
+            ),
+            label='Expand accordion by default',
+            section=_constants.SECTION,
+        ),
+    )
+    shared.opts.add_option(
+        key=_constants.ARH_UI_COMPONENT_ORDER_KEY,
+        info=shared.OptionInfo(
+            default=OPT_KEY_TO_DEFAULT_MAP.get(
+                _constants.ARH_UI_COMPONENT_ORDER_KEY,
+            ),
+            label='UI Component order',
+            component=gr.Dropdown,
+            component_args=lambda: {
+                'choices': [
+                    ', '.join(p) for p in itertools.permutations(
+                        DEFAULT_UI_COMPONENT_ORDER_KEY_LIST,
+                    )
+                ],
+            },
             section=_constants.SECTION,
         ),
     )

--- a/aspect_ratio_helper/main.py
+++ b/aspect_ratio_helper/main.py
@@ -33,7 +33,11 @@ class AspectRatioStepScript(scripts.Script):
             [component(self) for component in _settings.COMPONENTS],
         )
 
-        if not any(component.should_show() for component in components):
+        hide_accordion: bool = _settings.safe_opt(
+            _constants.ARH_HIDE_ACCORDION_BY_DEFAULT_KEY,
+        )
+
+        if hide_accordion or not any(c.should_show() for c in components):
             return  # no components should render, so just return.
 
         start_expanded: bool = _settings.safe_opt(


### PR DESCRIPTION
Thanks to [bryanray](https://github.com/bryanray) for raising in https://github.com/thomasasfk/sd-webui-aspect-ratio-helper/issues/27

You could already hide the accordion, by not showing any of the 3 column components. 

Adding an explicit option specifically for it is good though, as that is more intuitive overall imo.