### PR TITLE
Use 'change' over 'input' to support more options

### DIFF
--- a/javascript/aspectRatioController.js
+++ b/javascript/aspectRatioController.js
@@ -428,7 +428,7 @@ const postImageControllerSetupFunction = (controller) => {
         const imageContainer = document.getElementById(imageContainerId);
         const inputElement = imageContainer.querySelector('input');
         inputElement.parentElement.addEventListener('drop', scaleToImg2ImgImage);
-        inputElement.addEventListener('input', scaleToImg2ImgImage);
+        inputElement.addEventListener('change', scaleToImg2ImgImage);
     })
 
     addImg2ImgTabSwitchClickListeners(controller);


### PR DESCRIPTION
https://github.com/thomasasfk/sd-webui-aspect-ratio-helper/issues/42

Didn't realise it was that easy, ctrl + v works now, this also still works when manually selecting an image.